### PR TITLE
fix chatUser callback

### DIFF
--- a/lib/src/qiscus_core.dart
+++ b/lib/src/qiscus_core.dart
@@ -150,7 +150,9 @@ class QiscusSDK {
     @required String userId,
     Map<String, dynamic> extras,
     @required Function2<QChatRoom, Exception, void> callback,
-  }) {}
+  }) =>
+      chatUser$(userId: userId, extras: extras)
+          .toCallback2(callback);
 
   Future<void> clearMessagesByChatRoomId$({
     @required List<String> roomUniqueIds,


### PR DESCRIPTION
When calling `chatUser()` there's no return whether response return success or failure, the fix is  adding callback from `chatUser$()` 